### PR TITLE
Fixed duplicate error messages appearing

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Events, Partials } from 'discord.js';
+import { Client, GatewayIntentBits, Events } from 'discord.js';
 import { ADMIN_ROLE, bcParentGroup, TOKEN } from './src/config';
 import { getCommands, botHealth, divisionHelp } from './src/commands';
 import { ContentController } from './src/ContentController';
@@ -10,10 +10,7 @@ const client = new Client({
     intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.MessageContent,
-    ],
-    partials: [
-        Partials.Message
+        GatewayIntentBits.MessageContent
     ]
 });
 
@@ -70,7 +67,11 @@ client.on('interactionCreate', async (interaction) => {
 });
 
 client.on(Events.ThreadCreate, async (thrc) => {
+    const messagesInThread = await thrc.messages.fetch();
+
+    if (messagesInThread.some((mes) => mes.attachments.size === 0)) {
         await controller.createNewTask(thrc);
+    }
 });
 
 client.on(Events.MessageCreate, async (message) => {
@@ -79,15 +80,10 @@ client.on(Events.MessageCreate, async (message) => {
         return;
     }
 
-    if (message.partial) {
-        await message.fetch()
-    }
-
     if (message.attachments.size > 0) {
         await controller.addToPostQueue(message);
     }
 
-    
     controller.cleanUpTasks();
     controller.processQueue();
 });

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Events } from 'discord.js';
+import { Client, GatewayIntentBits, Events, Partials } from 'discord.js';
 import { ADMIN_ROLE, bcParentGroup, TOKEN } from './src/config';
 import { getCommands, botHealth, divisionHelp } from './src/commands';
 import { ContentController } from './src/ContentController';
@@ -10,7 +10,10 @@ const client = new Client({
     intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.MessageContent
+        GatewayIntentBits.MessageContent,
+    ],
+    partials: [
+        Partials.Message
     ]
 });
 
@@ -67,7 +70,7 @@ client.on('interactionCreate', async (interaction) => {
 });
 
 client.on(Events.ThreadCreate, async (thrc) => {
-    await controller.createNewTask(thrc);
+        await controller.createNewTask(thrc);
 });
 
 client.on(Events.MessageCreate, async (message) => {
@@ -76,10 +79,15 @@ client.on(Events.MessageCreate, async (message) => {
         return;
     }
 
+    if (message.partial) {
+        await message.fetch()
+    }
+
     if (message.attachments.size > 0) {
         await controller.addToPostQueue(message);
     }
 
+    
     controller.cleanUpTasks();
     controller.processQueue();
 });

--- a/src/ContentController.ts
+++ b/src/ContentController.ts
@@ -7,7 +7,8 @@ import {
     allAttahcmentsAreCorrectType,
     checkDateObject,
     getDivisionName,
-    hasRole
+    hasRole,
+    previousMessageIsBot
 } from './util';
 import { fetchGroups, searchGroupId } from './ballchasingAPI';
 import { CAPTAIN_ROLE, clearCacheInterval } from './config';
@@ -50,13 +51,16 @@ export class ContentController {
             const [groupId, allRecords] = searchGroupId(groupName, response);
             if (!groupId) {
                 log.error(`Group ID for ${groupName} not found`);
-                await thread.send(
-                    `Your post did not make too much sense to me, maybe theres a typo?\n` +
-                        `I tried with '${groupName}'\n` +
-                        `but only found groups named: \n${allRecords.join(
-                            '\n'
-                        )}`
-                );
+                const prevMsgIsBot = await previousMessageIsBot(thread)
+                if (!prevMsgIsBot) {
+                    thread.send(
+                        `Your post did not make too much sense to me, maybe theres a typo?\n` +
+                            `I tried with '${groupName}'\n` +
+                            `but only found groups named: \n${allRecords.join(
+                                '\n'
+                            )}`
+                    );
+                }
                 return;
             }
 

--- a/src/ContentController.ts
+++ b/src/ContentController.ts
@@ -7,8 +7,7 @@ import {
     allAttahcmentsAreCorrectType,
     checkDateObject,
     getDivisionName,
-    hasRole,
-    previousMessageIsBot
+    hasRole
 } from './util';
 import { fetchGroups, searchGroupId } from './ballchasingAPI';
 import { CAPTAIN_ROLE, clearCacheInterval } from './config';
@@ -51,16 +50,19 @@ export class ContentController {
             const [groupId, allRecords] = searchGroupId(groupName, response);
             if (!groupId) {
                 log.error(`Group ID for ${groupName} not found`);
-                const prevMsgIsBot = await previousMessageIsBot(thread)
-                if (!prevMsgIsBot) {
-                    thread.send(
+
+                await thread.sendTyping();
+
+                //This timeout is for UX reasons
+                setTimeout(async () => {
+                    await thread.send(
                         `Your post did not make too much sense to me, maybe theres a typo?\n` +
                             `I tried with '${groupName}'\n` +
                             `but only found groups named: \n${allRecords.join(
                                 '\n'
                             )}`
                     );
-                }
+                }, 3000);
                 return;
             }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { Attachment, Channel, Collection, Role, TextChannel, ThreadChannel } from 'discord.js';
+import { Attachment, Collection, Role } from 'discord.js';
 
 const reFileExtension = /(?:\.([^.]+))?$/;
 export const ACCEPTABLE_FILE_EXTENSION = '.replay';
@@ -45,14 +45,3 @@ export const checkDateObject = (date: Date, milliseconds?: number) => {
     //default 3 days
     return date < targetDate;
 };
-
-export const previousMessageIsBot = async (channel: ThreadChannel): Promise<boolean> => {
-    if (channel.partial) {
-        await channel.fetch(true)
-    }
-    const messages = await channel.messages.fetch({ limit: 10, cache: true });
-    messages.map((msg) => console.log(msg.content))
-    const prevMessage = messages.first()
-    //console.log(prevMessage.content, prevMessage.author.bot)
-    return prevMessage.author.bot
-}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { Attachment, Collection, Role } from 'discord.js';
+import { Attachment, Channel, Collection, Role, TextChannel, ThreadChannel } from 'discord.js';
 
 const reFileExtension = /(?:\.([^.]+))?$/;
 export const ACCEPTABLE_FILE_EXTENSION = '.replay';
@@ -45,3 +45,14 @@ export const checkDateObject = (date: Date, milliseconds?: number) => {
     //default 3 days
     return date < targetDate;
 };
+
+export const previousMessageIsBot = async (channel: ThreadChannel): Promise<boolean> => {
+    if (channel.partial) {
+        await channel.fetch(true)
+    }
+    const messages = await channel.messages.fetch({ limit: 10, cache: true });
+    messages.map((msg) => console.log(msg.content))
+    const prevMessage = messages.first()
+    //console.log(prevMessage.content, prevMessage.author.bot)
+    return prevMessage.author.bot
+}


### PR DESCRIPTION
If on thread creation, the initial message contains attachments, message creation will call `createNewTask` rather than the thread creation