### PR TITLE
handling of thread name update implemented

### DIFF
--- a/src/commands/interactions/rl_check.ts
+++ b/src/commands/interactions/rl_check.ts
@@ -1,7 +1,7 @@
 import { Channel, Collection } from 'discord.js';
 import { ContentController } from '../../ContentController';
 
-export const handleCheckCommand = async (
+export const processThreadsNotDoneYet = async (
     channels: Collection<string, Channel>,
     controller: ContentController
 ) => {


### PR DESCRIPTION
If a user misspells the division name, they are able to edit the thread name and by renaming it, the files will be then automatically reconsidered for processing